### PR TITLE
bug everyone class not fully working

### DIFF
--- a/MMM-Facial-Recognition.js
+++ b/MMM-Facial-Recognition.js
@@ -53,13 +53,13 @@ Module.register('MMM-Facial-Recognition',{
 
 	login_user: function () {
 
-		MM.getModules().withClass(this.config.defaultClass).exceptWithClass(this.config.everyoneClass).enumerate(function(module) {
+		MM.getModules().withClass(this.config.defaultClass).enumerate(function(module) {
 			module.hide(1000, function() {
 				Log.log(module.name + ' is hidden.');
 			});
 		});
 
-		MM.getModules().withClass(this.current_user).enumerate(function(module) {
+		MM.getModules().withClass(this.current_user + ' ' + this.config.everyoneClass).enumerate(function(module) {
 			module.show(1000, function() {
 				Log.log(module.name + ' is shown.');
 			});
@@ -69,13 +69,13 @@ Module.register('MMM-Facial-Recognition',{
 	},
 	logout_user: function () {
 
-		MM.getModules().withClass(this.current_user).enumerate(function(module) {
+		MM.getModules().withClass(this.current_user + ' ' + this.config.everyoneClass).enumerate(function(module) {
 			module.hide(1000, function() {
 				Log.log(module.name + ' is hidden.');
 			});
 		});
 
-		MM.getModules().withClass(this.config.defaultClass).exceptWithClass(this.config.everyoneClass).enumerate(function(module) {
+		MM.getModules().withClass(this.config.defaultClass).enumerate(function(module) {
 			module.show(1000, function() {
 				Log.log(module.name + ' is shown.');
 			});


### PR DESCRIPTION
Bug Description: if a module has only a class 'everyone' it never shows, even when a user is logged in

Analysis: in login_user only the modules with the current_user in their class are shown, The code specifies that modules with everyoneClass should not be turned off, but they were never turned on in the first place.
I think the confusion came from login turning off the modules with a default class except the one that had everyone in it: as they should stay on. However it makes the assumption that all modules with an everyone class has also a default class, which might not be the case.
Fix: re-write to add everyoneClass to the modules being turned on & off when user log in & out.
I cannot see the harm of turning on / off twice a class, so that might happen though...